### PR TITLE
Adding error handling

### DIFF
--- a/src/whoisapi/models/response.py
+++ b/src/whoisapi/models/response.py
@@ -21,7 +21,16 @@ def _string_value(values: dict, key: str) -> str:
 
 def _int_value(values: dict, key: str) -> int:
     if key in values:
-        return int(values[key])
+        try:
+            return int(values[key])
+        except (ValueError, Exception) as error:
+            _logger.error(
+            "Couldn't parse the int ({}: {}). Error occurred: {}".format(
+                key,
+                values[key],
+                error.__str__()
+            )
+        )
     return 0
 
 


### PR DESCRIPTION
Adding error handling for integer parsing in order to prevent crash on invalid postal address.

example crash:

`  File "/.local/lib/python3.8/site-packages/whoisapi/client.py", line 77, in data
    return WhoisRecord(parsed['WhoisRecord'])
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 336, in __init__
    self.registry_data = RegistryData(values['registryData'])
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 317, in __init__
    super().__init__(values)
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 287, in __init__
    self.registrant = Registrant(values['registrant'])
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 167, in __init__
    super().__init__(values)
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 153, in __init__
    self.postal_code = _int_value(values, 'postalCode')
  File "/.local/lib/python3.8/site-packages/whoisapi/models/response.py", line 24, in _int_value
    return int(values[key])
ValueError: invalid literal for int() with base 10: 'Unit 1006, 10/F, Enterprise Square 3, Kowloon Bay, Hong Kong Hong Kong 000000'`