### PR TITLE
Closes #8: Adds support for the rdap flag in RequestParameters

### DIFF
--- a/src/whoisapi/models/request.py
+++ b/src/whoisapi/models/request.py
@@ -9,6 +9,7 @@ class RequestParameters(BaseModel):
     - api_key
     - domain_name
     - output_format
+    - rdap
     - prefer_fresh
     - da
     - ip
@@ -31,6 +32,7 @@ class RequestParameters(BaseModel):
         - api_key - required
         - domain_name
         - output_format
+        - rdap
         - prefer_fresh
         - da
         - ip
@@ -42,6 +44,7 @@ class RequestParameters(BaseModel):
         self._api_key = ''
         self._domain_name = ''
         self._output_format = 'JSON'
+        self._rdap = 0
         self._prefer_fresh = 0
         self._da = 0
         self._ip = 0
@@ -58,6 +61,8 @@ class RequestParameters(BaseModel):
             self.domain_name = kwargs['domain_name']
         if 'output_format' in kwargs:
             self.output_format = kwargs['output_format']
+        if 'rdap' in kwargs:
+            self.rdap = kwargs['rdap']
         if 'prefer_fresh' in kwargs:
             self.prefer_fresh = kwargs['prefer_fresh']
         if 'da' in kwargs:
@@ -108,6 +113,17 @@ class RequestParameters(BaseModel):
         else:
             raise ParameterError(
                 "Output format should either JSON or XML.")
+
+    @property
+    def rdap(self):
+        return self._rdap
+
+    @rdap.setter
+    def rdap(self, value):
+        if int(value) in [0, 1]:
+            self._rdap = int(value)
+        else:
+            raise ParameterError("'rdap' should be 0 or 1.")
 
     @property
     def prefer_fresh(self):
@@ -193,6 +209,7 @@ class RequestParameters(BaseModel):
             'apiKey': self.api_key,
             'domainName': self.domain_name,
             'outputFormat': self.output_format,
+            'rdap': self.rdap,
             'da': self.da,
             'ip': self.ip,
             'ipWhois': self.ip_whois,

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -49,10 +49,24 @@ class TestClient(unittest.TestCase):
         whois = client.data('whoisxmlapi.com')
         assert whois.domain_availability is None
         assert len(whois.raw_text) > 20
-        params = RequestParameters(ignore_raw_texts=1, da=2)
-        whois2 = client.data('whoisxmlapi.com', params)
-        assert whois2.domain_availability is False
-        assert whois2.raw_text == ''
+
+        test_cases = [
+            {
+                'name': 'ignore_raw_texts and da parameters',
+                'domain': 'whoisxmlapi.com',
+                'params': RequestParameters(ignore_raw_texts=1, da=2),
+                'checks': [
+                    lambda w: w.domain_availability is False,
+                    lambda w: w.raw_text == ''
+                ]
+            },
+        ]
+
+        for case in test_cases:
+            with self.subTest(msg=case['name']):
+                whois = client.data(case['domain'], params=case['params'])
+                for check in case['checks']:
+                    self.assertTrue(check(whois))
 
 
 if __name__ == '__main__':

--- a/tests/client_test.py
+++ b/tests/client_test.py
@@ -60,6 +60,15 @@ class TestClient(unittest.TestCase):
                     lambda w: w.raw_text == ''
                 ]
             },
+            {
+                'name': 'rdap parameter',
+                'domain': 'icann.org',
+                'params': RequestParameters(rdap=1),
+                'checks': [
+                    lambda w: w.registrar_name == 'CSC Corporate Domains, Inc.',
+                    lambda w: w.contact_email == 'domainabuse@cscglobal.com'
+                ]
+            },
         ]
 
         for case in test_cases:


### PR DESCRIPTION
# Overview
Adds an rdap parameter to RequestParameters, allowing users to pass rdap=1 (or 0) as part of the request.

# Changes

Introduced the rdap flag with basic validation.
Added a test case confirming rdap is correctly included in the parameters.

# Closes #8 

All tests pass locally. Let me know if you need any adjustments.